### PR TITLE
Initial TravisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: trusty
+language: node_js
+node_js:
+- "stable"
+before_script:
+- npm install
+script:
+- npm run build
+deploy:
+  tag: next
+  on:
+    branch: master
+  provider: npm
+  email: $NPM_EMAIL
+  api_key: $NPM_AUTH_TOKEN
+deploy:
+  provider: s3
+  access_key_id: $AWS_ACCESS_ID
+  secret_access_key: $AWS_SECRET_ID
+  bucket: 'factor-ui'
+  local_dir: dist
+  skip_cleanup: true
+  on:
+    branch: master
+after_deploy:
+  - travis-ci-cloudfront-invalidation -a $AWS_ACCESS_ID -s $AWS_SECRET_ID -c $CF_ID -i '/*' -b $TRAVIS_BRANCH -p $TRAVIS_PULL_REQUEST

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Factor UI
 
+[![Build Status](https://travis-ci.com/mozilla-it/factor-ui.svg?branch=master)](https://travis-ci.com/mozilla-it/factor-ui)
+
 ## Project description
 
 This will be a central repository for internally shared templates and components within Mozilla. This README will be the central location for all documentation relating to our internal components.


### PR DESCRIPTION
This pull request (PR) adds support for deployment to both NPM and AWS Cloudfront.  The variables need added as a Travis secret and the proper AWS S3 bucket and Cloudfront setup.  A determination of what AWS account that the components should live in needs to be determined.